### PR TITLE
Opt-in/out & user properties

### DIFF
--- a/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/AnalyticsService.kt
+++ b/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/AnalyticsService.kt
@@ -12,14 +12,9 @@ interface AnalyticsService {
     val name: String
 
     /*
-    Enables the analytics collection
+    Enables/Disables the analytics collection
      */
-    fun enableAnalyticsCollection()
-
-    /*
-    Disables the analytics collection
-     */
-    fun disableAnalyticsCollection()
+    var enabled: Boolean
 
     /*
     userId: Id of the logged in user
@@ -69,13 +64,11 @@ interface AnalyticsService {
 
         override val name = currentAnalyticsService().name
 
-        override fun enableAnalyticsCollection() {
-            currentAnalyticsService().enableAnalyticsCollection()
-        }
-
-        override fun disableAnalyticsCollection() {
-            currentAnalyticsService().disableAnalyticsCollection()
-        }
+        override var enabled: Boolean
+            get() = currentAnalyticsService().enabled
+            set(value) {
+                currentAnalyticsService().enabled = value
+            }
 
         override fun identifyUser(userId: String, properties: AnalyticsPropertiesType) {
             currentAnalyticsService().identifyUser(userId, properties)

--- a/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/AnalyticsServiceLogger.kt
+++ b/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/AnalyticsServiceLogger.kt
@@ -5,13 +5,12 @@ import com.mirego.trikot.foundation.concurrent.AtomicReference
 class AnalyticsServiceLogger(private val analyticsService: AnalyticsService) : AnalyticsService {
     override val name: String = "AnalyticsServiceLogger"
 
-    override fun enableAnalyticsCollection() {
-        println("Analytics - Enable (Service: ${analyticsService.name})")
-    }
-
-    override fun disableAnalyticsCollection() {
-        println("Analytics - Disable (Service: ${analyticsService.name})")
-    }
+    override var enabled: Boolean
+        get() = analyticsService.enabled
+        set(value) {
+            println("Analytics - enabled changed to $value (Service: ${analyticsService.name})")
+            analyticsService.enabled = value
+        }
 
     private val superProperties = AtomicReference<AnalyticsPropertiesType>(mapOf())
 

--- a/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/EmptyAnalyticsService.kt
+++ b/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/EmptyAnalyticsService.kt
@@ -2,11 +2,8 @@ package com.mirego.trikot.analytics
 
 class EmptyAnalyticsService : AnalyticsService {
     override val name: String = "ANALYTICS SERVICE NOT CONFIGURED"
-    override fun enableAnalyticsCollection() {
-    }
 
-    override fun disableAnalyticsCollection() {
-    }
+    override var enabled = false
 
     override fun identifyUser(userId: String, properties: AnalyticsPropertiesType) {
     }


### PR DESCRIPTION
## Description
Three functionalities are now added to Trikot analytics:

- Analytics collection opt-out
- Analytics collection opt-in
- Setting user profile properties

## Motivation and Context

In Galileo, it is required to be able to opt-in/out from the analytics collection and be able to track user properties, not only when identifying a user.

## How Has This Been Tested?
Tested using mavenLocal and another project.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
