### PR TITLE
Rename enable to isEnabled property 

### DIFF
--- a/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/AnalyticsService.kt
+++ b/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/AnalyticsService.kt
@@ -14,7 +14,7 @@ interface AnalyticsService {
     /*
     Enables/Disables the analytics collection
      */
-    var enabled: Boolean
+    var isEnabled: Boolean
 
     /*
     userId: Id of the logged in user
@@ -64,10 +64,10 @@ interface AnalyticsService {
 
         override val name = currentAnalyticsService().name
 
-        override var enabled: Boolean
-            get() = currentAnalyticsService().enabled
+        override var isEnabled: Boolean
+            get() = currentAnalyticsService().isEnabled
             set(value) {
-                currentAnalyticsService().enabled = value
+                currentAnalyticsService().isEnabled = value
             }
 
         override fun identifyUser(userId: String, properties: AnalyticsPropertiesType) {

--- a/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/AnalyticsServiceLogger.kt
+++ b/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/AnalyticsServiceLogger.kt
@@ -5,11 +5,11 @@ import com.mirego.trikot.foundation.concurrent.AtomicReference
 class AnalyticsServiceLogger(private val analyticsService: AnalyticsService) : AnalyticsService {
     override val name: String = "AnalyticsServiceLogger"
 
-    override var enabled: Boolean
-        get() = analyticsService.enabled
+    override var isEnabled: Boolean
+        get() = analyticsService.isEnabled
         set(value) {
             println("Analytics - enabled changed to $value (Service: ${analyticsService.name})")
-            analyticsService.enabled = value
+            analyticsService.isEnabled = value
         }
 
     private val superProperties = AtomicReference<AnalyticsPropertiesType>(mapOf())

--- a/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/EmptyAnalyticsService.kt
+++ b/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/EmptyAnalyticsService.kt
@@ -3,7 +3,7 @@ package com.mirego.trikot.analytics
 class EmptyAnalyticsService : AnalyticsService {
     override val name: String = "ANALYTICS SERVICE NOT CONFIGURED"
 
-    override var enabled = false
+    override var isEnabled = false
 
     override fun identifyUser(userId: String, properties: AnalyticsPropertiesType) {
     }

--- a/firebase-ktx/build.gradle
+++ b/firebase-ktx/build.gradle
@@ -31,10 +31,10 @@ configurations.all {
 }
 
 dependencies {
-    api 'com.mirego.trikot:analytics:0.10.1'
+    api 'com.mirego.trikot:analytics:0.11.1'
     api "com.mirego.trikot:streams:$trikot_streams_version"
     api "com.mirego.trikot:trikotFoundation:$trikot_foundation_version"
-    implementation "com.google.firebase:firebase-analytics:17.2.1"
+    implementation "com.google.firebase:firebase-analytics:17.4.2"
     implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0'
     implementation 'androidx.lifecycle:lifecycle-reactivestreams-ktx:2.1.0'
 }

--- a/firebase-ktx/build.gradle
+++ b/firebase-ktx/build.gradle
@@ -31,7 +31,7 @@ configurations.all {
 }
 
 dependencies {
-    api 'com.mirego.trikot:analytics:0.11.1'
+    api 'com.mirego.trikot:analytics:0.12.1'
     api "com.mirego.trikot:streams:$trikot_streams_version"
     api "com.mirego.trikot:trikotFoundation:$trikot_foundation_version"
     implementation "com.google.firebase:firebase-analytics:17.4.2"

--- a/firebase-ktx/src/main/java/com/mirego/trikot/analytics/FirebaseAnalyticsService.kt
+++ b/firebase-ktx/src/main/java/com/mirego/trikot/analytics/FirebaseAnalyticsService.kt
@@ -9,12 +9,12 @@ class FirebaseAnalyticsService(context: Context, analyticsEnabled: Boolean = tru
 
     private var firebaseAnalytics = FirebaseAnalytics.getInstance(context)
 
-    private var isEnabled: Boolean = analyticsEnabled
+    private var analyticsEnabled: Boolean = analyticsEnabled
 
-    override var enabled: Boolean
-        get() = isEnabled
+    override var isEnabled: Boolean
+        get() = analyticsEnabled
         set(value) {
-            isEnabled = value
+            analyticsEnabled = value
             firebaseAnalytics.setAnalyticsCollectionEnabled(value)
         }
 

--- a/mixpanel-ktx/build.gradle
+++ b/mixpanel-ktx/build.gradle
@@ -31,7 +31,7 @@ configurations.all {
 }
 
 dependencies {
-    api 'com.mirego.trikot:analytics:0.10.1'
+    api 'com.mirego.trikot:analytics:0.12.1'
     api "com.mirego.trikot:streams:$trikot_streams_version"
     api "com.mirego.trikot:trikotFoundation:$trikot_foundation_version"
     implementation 'com.mixpanel.android:mixpanel-android:5.8.2'

--- a/mixpanel-ktx/src/main/java/com/mirego/trikot/analytics/MixpanelAnalyticsService.kt
+++ b/mixpanel-ktx/src/main/java/com/mirego/trikot/analytics/MixpanelAnalyticsService.kt
@@ -12,7 +12,7 @@ class MixpanelAnalyticsService(
     private val mixpanelAnalytics =
         MixpanelAPI.getInstance(context, mixpanelToken, !analyticsEnabled)
 
-    override var enabled: Boolean
+    override var isEnabled: Boolean
         get() = !mixpanelAnalytics.hasOptedOutTracking()
         set(value) {
             if (value) {

--- a/swift-extensions/firebase/FirebaseAnalyticsService.swift
+++ b/swift-extensions/firebase/FirebaseAnalyticsService.swift
@@ -7,12 +7,12 @@ public class FirebaseAnalyticsService: AnalyticsService {
     private var superProperties = [String: Any]()
 
     public init(enableAnalytics: Bool = true) {
-        enabled = enableAnalytics
+        isEnabled = enableAnalytics
     }
 
-    public var enabled: Bool {
+    public var isEnabled: Bool {
         didSet {
-            Analytics.setAnalyticsCollectionEnabled(enabled)
+            Analytics.setAnalyticsCollectionEnabled(isEnabled)
         }
     }
 

--- a/swift-extensions/mixpanel/MixpanelAnalyticsService.swift
+++ b/swift-extensions/mixpanel/MixpanelAnalyticsService.swift
@@ -4,12 +4,12 @@ import TRIKOT_FRAMEWORK_NAME
 
 public class MixpanelAnalyticsService: AnalyticsService {
     public init(enableAnalytics: Bool = true) {
-        enabled = enableAnalytics
+        isEnabled = enableAnalytics
     }
 
-    public var enabled: Bool {
+    public var isEnabled: Bool {
         didSet {
-            if enabled {
+            if isEnabled {
                 Mixpanel.mainInstance().optInTracking()
             }
             else {


### PR DESCRIPTION
Rename enabled property to isEnabled so it no longer clashes with ios trikot.viewmodels enabled property.

## Description
We were seeing strange behaviours when using ios version of this library combined with the trikot.viewmodels lib. Renaming the enabled property to isEnabled will fix this issue.

## How Has This Been Tested?
Tested in my app

## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

Please note that build will fail until I release trikot.analytics since the firebase and mixpanel ktx are already updated at the futur 0.12.1 version 
