### PR TITLE
Upgrade to Kotlin 1.4

### DIFF
--- a/analytics/build.gradle
+++ b/analytics/build.gradle
@@ -10,6 +10,7 @@ repositories {
     google()
     jcenter()
     mavenCentral()
+    mavenLocal()
     maven { url "https://kotlin.bintray.com/kotlinx" }
     maven { url 'https://jitpack.io' }
     maven { url('https://s3.amazonaws.com/mirego-maven/public') }
@@ -17,7 +18,6 @@ repositories {
 
 android {
     compileSdkVersion 29
-    buildToolsVersion "29.0.3"
 
     defaultConfig {
         minSdkVersion 14
@@ -28,66 +28,62 @@ android {
 group 'com.mirego.trikot'
 
 kotlin {
-    targets {
-        fromPreset(presets.jvm, 'jvm')
-        fromPreset(presets.js, 'js')
-        fromPreset(presets.android, 'android')
-        fromPreset(presets.iosArm64, 'iosArm64')
-        fromPreset(presets.iosX64, 'iosX64')
+    jvm()
+    ios()
+    iosArm32('iosArm32')
+    tvos()
+    js {
+        browser()
+        nodejs()
     }
+
     android {
         publishAllLibraryVariants()
     }
+
     sourceSets {
         commonMain {
             dependencies {
                 implementation "com.mirego.trikot:streams:$trikot_streams_version"
                 implementation "com.mirego.trikot:viewmodels:$trikot_viewmodels_version"
                 implementation "com.mirego.trikot:trikotFoundation:$trikot_foundation_version"
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-common'
             }
         }
+
         jvmMain {
-            dependencies {
-                implementation "com.mirego.trikot:streams-jvm:$trikot_streams_version"
-                implementation "com.mirego.trikot:viewmodels-jvm:$trikot_viewmodels_version"
-                implementation "com.mirego.trikot:trikotFoundation-jvm:$trikot_foundation_version"
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
-            }
+            dependsOn commonMain
         }
+
         androidMain {
-            dependencies {
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-jdk8'
-            }
+            dependsOn commonMain
         }
+
         jsMain {
-            dependencies {
-                implementation "com.mirego.trikot:streams-js:$trikot_streams_version"
-                implementation "com.mirego.trikot:viewmodels-js:$trikot_viewmodels_version"
-                implementation "com.mirego.trikot:trikotFoundation-js:$trikot_foundation_version"
-                implementation 'org.jetbrains.kotlin:kotlin-stdlib-js'
-            }
+            dependsOn commonMain
         }
+
         nativeMain {
-            dependsOn(commonMain)
+            dependsOn commonMain
+        }
+
+        iosArm32Main {
+            dependsOn(nativeMain)
         }
 
         iosArm64Main {
-            dependsOn(nativeMain)
-            dependencies {
-                implementation "com.mirego.trikot:streams-iosarm64:$trikot_streams_version"
-                implementation "com.mirego.trikot:viewmodels-iosarm64:$trikot_viewmodels_version"
-                implementation "com.mirego.trikot:trikotFoundation-iosarm64:$trikot_foundation_version"
-            }
+            dependsOn nativeMain
         }
 
         iosX64Main {
+            dependsOn nativeMain
+        }
+
+        tvosArm64Main {
             dependsOn(nativeMain)
-            dependencies {
-                implementation "com.mirego.trikot:streams-iosx64:$trikot_streams_version"
-                implementation "com.mirego.trikot:viewmodels-iosx64:$trikot_viewmodels_version"
-                implementation "com.mirego.trikot:trikotFoundation-iosx64:$trikot_foundation_version"
-            }
+        }
+
+        tvosX64Main {
+            dependsOn(nativeMain)
         }
     }
 }
@@ -95,5 +91,5 @@ kotlin {
 release {
    checkTasks = ['check']
    buildTasks = ['publish']
-   updateVersionPart = 1
+   updateVersionPart = 2
 }

--- a/analytics/gradle.properties
+++ b/analytics/gradle.properties
@@ -1,2 +1,2 @@
 #Thu Jun 04 19:48:10 EDT 2020
-version=0.13.1-SNAPSHOT
+version=1.0.0-SNAPSHOT

--- a/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/TrackableViewModelAction.kt
+++ b/analytics/src/commonMain/kotlin/com/mirego/trikot/analytics/TrackableViewModelAction.kt
@@ -1,8 +1,8 @@
 package com.mirego.trikot.analytics
 
+import com.mirego.trikot.streams.reactive.just
 import com.mirego.trikot.viewmodels.properties.ViewModelAction
 import com.mirego.trikot.viewmodels.properties.ViewModelActionBlock
-import com.mirego.trikot.streams.reactive.just
 import org.reactivestreams.Publisher
 
 class TrackableViewModelAction(private val event: AnalyticsEvent, private val properties: Publisher<AnalyticsPropertiesType> = mapOf<String, Any>().just(), actionBlock: ViewModelActionBlock) : ViewModelAction(actionBlock) {

--- a/build.gradle
+++ b/build.gradle
@@ -6,9 +6,9 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:3.5.0'
+        classpath 'com.android.tools.build:gradle:3.5.4'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        classpath 'org.jlleitschuh.gradle:ktlint-gradle:8.0.0'
+        classpath 'org.jlleitschuh.gradle:ktlint-gradle:9.1.1'
     }
 }
 

--- a/firebase-ktx/build.gradle
+++ b/firebase-ktx/build.gradle
@@ -10,6 +10,7 @@ plugins {
 repositories {
     google()
     jcenter()
+    mavenLocal()
     mavenCentral()
     maven { url('https://s3.amazonaws.com/mirego-maven/public') }
 }
@@ -18,7 +19,7 @@ group 'com.mirego.trikot.analytics'
 
 android {
     compileSdkVersion 29
-    buildToolsVersion "29.0.2"
+    buildToolsVersion "29.0.3"
 
     defaultConfig {
         minSdkVersion 21
@@ -31,18 +32,18 @@ configurations.all {
 }
 
 dependencies {
-    api 'com.mirego.trikot:analytics:0.12.1'
+    api 'com.mirego.trikot:analytics:1.0.0'
     api "com.mirego.trikot:streams:$trikot_streams_version"
     api "com.mirego.trikot:trikotFoundation:$trikot_foundation_version"
-    implementation "com.google.firebase:firebase-analytics:17.4.2"
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0'
-    implementation 'androidx.lifecycle:lifecycle-reactivestreams-ktx:2.1.0'
+    implementation "com.google.firebase:firebase-analytics:17.5.0"
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
+    implementation 'androidx.lifecycle:lifecycle-reactivestreams-ktx:2.2.0'
 }
 
 release {
     checkTasks = ['check']
     buildTasks = ['publish']
-    updateVersionPart = 1
+    updateVersionPart = 2
     tagPrefix = 'firebase-ktx-'
 }
 

--- a/firebase-ktx/gradle.properties
+++ b/firebase-ktx/gradle.properties
@@ -1,2 +1,2 @@
 #Thu Jun 04 19:50:34 EDT 2020
-version=0.10.1-SNAPSHOT
+version=1.0.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,8 +1,8 @@
 kotlin.code.style=official
-kotlin_version=1.3.70
-trikot_foundation_version=0.29.1
-trikot_streams_version=0.56.1
-trikot_viewmodels_version=0.48.1
+kotlin_version=1.4.0
+trikot_foundation_version=1.0.0
+trikot_streams_version=1.0.0
+trikot_viewmodels_version=1.0.0
 android.useAndroidX=true
 android.enableJetifier=true
 kapt.incremental.apt=true
@@ -10,3 +10,5 @@ org.gradle.parallel=true
 org.gradle.configureondemand=true
 org.gradle.jvmargs=-Xmx3072m -XX:MaxPermSize=512m -XX:+HeapDumpOnOutOfMemoryError -Dfile.encoding=UTF-8
 org.gradle.caching=true
+kotlin.mpp.enableGranularSourceSetsMetadata=true
+kotlin.native.enableDependencyPropagation=false

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.5.1-all.zip

--- a/mixpanel-ktx/build.gradle
+++ b/mixpanel-ktx/build.gradle
@@ -10,6 +10,7 @@ plugins {
 repositories {
     google()
     jcenter()
+    mavenLocal()
     mavenCentral()
     maven { url('https://s3.amazonaws.com/mirego-maven/public') }
 }
@@ -18,7 +19,7 @@ group 'com.mirego.trikot.analytics'
 
 android {
     compileSdkVersion 29
-    buildToolsVersion "29.0.2"
+    buildToolsVersion "29.0.3"
 
     defaultConfig {
         minSdkVersion 21
@@ -31,18 +32,18 @@ configurations.all {
 }
 
 dependencies {
-    api 'com.mirego.trikot:analytics:0.12.1'
+    api 'com.mirego.trikot:analytics:1.0.0'
     api "com.mirego.trikot:streams:$trikot_streams_version"
     api "com.mirego.trikot:trikotFoundation:$trikot_foundation_version"
     implementation 'com.mixpanel.android:mixpanel-android:5.8.2'
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.1.0'
-    implementation 'androidx.lifecycle:lifecycle-reactivestreams-ktx:2.1.0'
+    implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
+    implementation 'androidx.lifecycle:lifecycle-reactivestreams-ktx:2.2.0'
 }
 
 release {
     checkTasks = ['check']
     buildTasks = ['publish']
-    updateVersionPart = 1
+    updateVersionPart = 2
     tagPrefix = 'mixpanel-ktx-'
 }
 

--- a/mixpanel-ktx/gradle.properties
+++ b/mixpanel-ktx/gradle.properties
@@ -1,2 +1,2 @@
 #Thu Jun 04 19:52:07 EDT 2020
-version=0.4.1-SNAPSHOT
+version=1.0.0-SNAPSHOT

--- a/settings.gradle
+++ b/settings.gradle
@@ -22,7 +22,5 @@ pluginManagement {
     }
 }
 rootProject.name = 'trikot.analytics'
-enableFeaturePreview("GRADLE_METADATA")
 
-include ':analytics', ':firebase-ktx'
-include ':analytics', ':mixpanel-ktx'
+include ':analytics', ':firebase-ktx' , ':mixpanel-ktx'


### PR DESCRIPTION
## Description
- Update Kotlin compiler to 1.4.0
- Remove GRADLE_METADATA flag as module metadata is used in dependency resolution and included in publications by default in Gradle 6.0 and above
- Remove manual stdlib dependencies as they are now included by default
- Migrate to hierarchical project structure and use platform shortcuts.
- Bump version number to 1.0.0 and migrate to semantic versioning

## Motivation and Context
As Kotlin 1.4 has been officially released in the stable channel, it is time to update.

## How Has This Been Tested?
Not yet tested in production app

## Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to change)
